### PR TITLE
Add smartRounding method for round percents

### DIFF
--- a/round/round.go
+++ b/round/round.go
@@ -1,0 +1,147 @@
+package round
+
+import (
+	"fmt"
+	"math"
+	"sort"
+)
+
+type Value interface {
+	GetFloatValue() float64
+	SetFloatValue(value float64)
+}
+
+type Values []Value
+
+type SortValues struct {
+	values         []float64
+	orginalIndexes []int
+}
+
+func newSortValues(values []Value) SortValues {
+	indexes := make([]int, len(values))
+	valuesCopy := make([]float64, len(values))
+
+	for i := 0; i < len(values); i++ {
+		indexes[i] = i
+		valuesCopy[i] = values[i].GetFloatValue()
+	}
+
+	return SortValues{
+		values:         valuesCopy,
+		orginalIndexes: indexes,
+	}
+}
+
+func (s SortValues) Len() int {
+	return len(s.values)
+}
+
+func (s SortValues) Less(i, j int) bool {
+	iDecimal, jDecimal := getDecimalPart(s.values[i]), getDecimalPart(s.values[j])
+
+	if iDecimal == jDecimal {
+		return s.values[i] > s.values[j]
+	}
+
+	return iDecimal > jDecimal
+}
+
+func (s SortValues) Swap(i, j int) {
+	s.values[i], s.values[j] = s.values[j], s.values[i]
+	s.orginalIndexes[i], s.orginalIndexes[j] = s.orginalIndexes[j], s.orginalIndexes[i]
+}
+
+func getDecimalPart(x float64) float64 {
+	return x - math.Trunc(x)
+}
+
+// SmartRound - method for rounding percents to integers
+// in sum it must be 100% (can be changed in requiredSum argument)
+// it's use larges reminder method but keep this extra requirement:
+// - if values is equal, after rounding the must be equal (if it possible)
+// 		example: 66.6666%, 16.666%, 16.666%
+// 		correct: 66, 17, 17
+// 		incorrect: 67, 17, 16
+func SmartRound(values Values, requiredSum int) error {
+	sorted := newSortValues(values)
+
+	// sort by decimal part, for equal decimal parts, use integer part
+	sort.Sort(sorted)
+
+	var actualSum float64
+
+	// equalGroups it's a map for save info about equal values
+	// equal values already grouped in array, because it's sorted
+	equalGroups := make(map[int]int, 0)
+
+	currentEqualGroupIndex := -1
+	for i, value := range sorted.values {
+		if i+1 < len(sorted.values) && sorted.values[i] == sorted.values[i+1] {
+			if currentEqualGroupIndex >= 0 {
+				equalGroups[currentEqualGroupIndex] = i + 1
+			} else {
+				equalGroups[i] = i + 1
+				currentEqualGroupIndex = i
+			}
+		} else {
+			currentEqualGroupIndex = -1
+		}
+
+		integerPart := math.Trunc(value)
+		sorted.values[i] = integerPart
+		actualSum += integerPart
+	}
+
+	diff := requiredSum - int(actualSum)
+
+	// save equality for groups if it possible
+	for start, end := range equalGroups {
+		if start < diff && end < diff {
+			addOne(sorted.values, start, end)
+			diff -= (end - start) + 1
+		} else if start < diff && end >= diff {
+			if diff-(end-start) > 0 {
+				addOne(sorted.values, start, end)
+				diff -= (end - start) + 1
+			}
+		}
+	}
+
+	if diff >= len(values) {
+		return fmt.Errorf("can't round values to get sum = %d", requiredSum)
+	}
+
+	if diff > 0 {
+		for i := 0; i < len(values) && diff > 0; i++ {
+			if end, exist := equalGroups[i]; exist {
+				i = end
+				continue
+			}
+
+			sorted.values[i] += 1
+			diff--
+		}
+	}
+
+	if diff > 0 {
+		addOne(sorted.values, 0, diff-1)
+	}
+
+	// restore original order for array
+	for i := 0; i < len(sorted.values); i++ {
+		originalIndex := sorted.orginalIndexes[i]
+
+		originalValue := sorted.values[i]
+
+		values[originalIndex].SetFloatValue(originalValue)
+	}
+
+	return nil
+}
+
+func addOne(arr []float64, start, end int) {
+	for i := start; i <= end; i++ {
+		arr[i] += 1
+	}
+}

--- a/round/round_test.go
+++ b/round/round_test.go
@@ -1,0 +1,206 @@
+package round
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type ValueFloat struct {
+	v float64
+}
+
+func (m ValueFloat) GetFloatValue() float64 {
+	return m.v
+}
+
+func (m *ValueFloat) SetFloatValue(value float64) {
+	m.v = value
+}
+
+func TestRoundToLargestRemainder(t *testing.T) {
+	type testCases struct {
+		description    string
+		input          []float64
+		expectedResult []float64
+		expectedError  error
+	}
+
+	for _, scenario := range []testCases{
+		{
+			description: "real case",
+			input: []float64{
+				48.648648648648646,
+				40.54054054054054,
+				10.81081081081081,
+			},
+			expectedResult: []float64{49, 40, 11},
+			expectedError:  nil,
+		},
+		{
+			description: "noramal test case 1",
+			input: []float64{
+				(15.0 / 30) * 100.0, // 50 %
+				(10.0 / 30) * 100.0, // 33.3333 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+			},
+			expectedResult: []float64{50, 33, 17},
+			expectedError:  nil,
+		},
+		{
+			description: "noramal test case 2",
+			input: []float64{
+				(10.0 / 30) * 100.0, // 33.3333 %
+				(10.0 / 30) * 100.0, // 33.3333 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+			},
+			expectedResult: []float64{33, 33, 17, 17},
+			expectedError:  nil,
+		},
+		{
+			description: "noramal test case 3",
+			input: []float64{
+				(10.0 / 30) * 100.0, // 33.3333 %
+				(6.0 / 30) * 100.0,  // 20 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+				(2.0 / 30) * 100.0,  // 6.666 %
+				(1.0 / 30) * 100.0,  // 3.3333 %
+				(1.0 / 30) * 100.0,  // 3.3333 %
+			},
+			expectedResult: []float64{33, 20, 17, 17, 7, 3, 3},
+			expectedError:  nil,
+		},
+		{
+			description: "noramal test case 4",
+			input: []float64{
+				(10.0 / 30) * 100.0, // 33.3333 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+				(3.0 / 30) * 100.0,  // 10 %
+				(1.0 / 30) * 100.0,  // 3.3333 %
+				(1.0 / 30) * 100.0,  // 3.3333 %
+			},
+			expectedResult: []float64{33, 17, 17, 17, 10, 3, 3},
+			expectedError:  nil,
+		},
+		{
+			description: "noramal test case 5",
+			input: []float64{
+				(10.0 / 30) * 100.0, // 33.3333 %
+				(6.0 / 30) * 100.0,  // 20 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+				(1.0 / 30) * 100.0,  // 3.3333 %
+				(1.0 / 30) * 100.0,  // 3.3333 %
+				(1.0 / 30) * 100.0,  // 3.3333 %
+				(1.0 / 30) * 100.0,  // 3.3333 %
+			},
+			expectedResult: []float64{34, 20, 17, 17, 3, 3, 3, 3},
+			expectedError:  nil,
+		},
+
+		{
+			description: "normal test case 6",
+			input: []float64{
+				(3.0 / 7) * 100.0, // 42.857142857142855 %
+				(2.0 / 7) * 100.0, // 28.5714285714285 %
+				(1.0 / 7) * 100.0, // 14.285714285714285 %
+				(1.0 / 7) * 100.0, // 14.285714285714285 %
+			},
+			expectedResult: []float64{43, 29, 14, 14},
+			expectedError:  nil,
+		},
+
+		{
+			description: "normal test case 7",
+			input: []float64{
+				(15.0 / 19) * 100.0, // 78.94736842105263 %
+				(2.0 / 19) * 100.0,  // 10.526315789473684 %
+				(1.0 / 19) * 100.0,  // 5.263157894736842 %
+				(1.0 / 19) * 100.0,  // 5.263157894736842 %
+			},
+			expectedResult: []float64{79, 11, 5, 5},
+			expectedError:  nil,
+		},
+
+		// save equal tests
+
+		{
+			description: "save equal for 16 and 16",
+			input: []float64{
+				(20.0 / 30) * 100.0, // 66.6666 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+				(5.0 / 30) * 100.0,  // 16.666 %
+			},
+			expectedResult: []float64{66, 17, 17},
+			expectedError:  nil,
+		},
+
+		{
+			description: "save equal for 5, 5, 5. round 84 to 85",
+			input: []float64{
+				(16.0 / 19) * 100.0, // 84.21052631578947 %
+				(1.0 / 19) * 100.0,  // 5.263157894736842 %
+				(1.0 / 19) * 100.0,  // 5.263157894736842 %
+				(1.0 / 19) * 100.0,  // 5.263157894736842 %
+			},
+			expectedResult: []float64{85, 5, 5, 5},
+			expectedError:  nil,
+		},
+
+		// IMPORTANT //
+		// this test case shows a case that
+		// does not allow rounding to integer values
+		// without losing the equality of numbers
+		{
+			description: "test case 2 problem",
+			input: []float64{
+				33.333333,
+				33.333333,
+				33.333333,
+			},
+			expectedResult: []float64{34, 33, 33},
+			// ALTERNATIVE expectedResult: []float64{33.3, 33.3, 33.3},
+			expectedError: nil,
+		},
+
+		// INVALID INPUT
+		{
+			description: "save equal for 5, 5, 5. round 84 to 85",
+			input: []float64{
+				1,
+				8,
+				9,
+			},
+			expectedResult: []float64{},
+			expectedError:  errors.New("any error"),
+		},
+	} {
+		t.Run(scenario.description, func(t *testing.T) {
+
+			values := make([]Value, len(scenario.input))
+			expectedValues := make([]Value, len(scenario.expectedResult))
+
+			for i := 0; i < len(scenario.input); i++ {
+				values[i] = &ValueFloat{v: scenario.input[i]}
+				if len(expectedValues) > i {
+					expectedValues[i] = &ValueFloat{v: scenario.expectedResult[i]}
+				}
+			}
+
+			err := SmartRound(values, 100)
+
+			if scenario.expectedError != nil {
+				require.NotNil(t, err)
+			}
+			if len(expectedValues) > 0 {
+				require.Equal(t, values, expectedValues)
+			}
+		})
+	}
+
+}

--- a/round/round_test.go
+++ b/round/round_test.go
@@ -31,9 +31,9 @@ func TestRoundToLargestRemainder(t *testing.T) {
 		{
 			description: "real case",
 			input: []float64{
-				48.648648648648646,
-				40.54054054054054,
-				10.81081081081081,
+				(18.0 / 37) * 100, // 48.648648648648646 %
+				(15.0 / 37) * 100, // 40.54054054054054 %
+				(4.0 / 37) * 100,  // 10.81081081081081 %
 			},
 			expectedResult: []float64{49, 40, 11},
 			expectedError:  nil,


### PR DESCRIPTION
Сделал функцию которая округляет проценты до целых чисел что бы в сумме сохранялось 100%

за основу взял метод наибольшего остатка:
1. Округление всего вниз
2. Получение разницы в сумме и 100
3. Распределение разности путем добавления 1 к элементам в порядке убывания их десятичных частей

Но у него есть недостаток что может теряться равенство между числами.
И я решил добавить исключение:
- Если есть равные числа и после округления они теряют равенство (тоесть к одному прибались +1 а к другому нет) то делать +1 к двум числам, либо не прибавлять вообще **если это возможно***.

*Есть случаи когда так округлить и сохранить равенстов нельзя, например:
(10 / 30) * 100 = 33.333%
(10 / 30) * 100 = 33.333%
(10 / 30) * 100 = 33.333%
тут уже ничего не поделать, добавляем +1 к любому (тоесть получаем вот так 34, 33, 33)


will be used in https://github.com/acretrader/general/issues/4519