### PR TITLE
Add auth by identity_id header

### DIFF
--- a/server/http.go
+++ b/server/http.go
@@ -105,7 +105,7 @@ func NewHttpServer(e *echo.Echo, l logger.Logger, cfg *Config, authTool middlewa
 	}
 }
 
-func New() *HttpServer {
+func New(authTool middleware.AuthMiddleware) *HttpServer {
 	cfg := &Config{}
 	l := logger.NewComponentLogger("http_server", nil)
 
@@ -113,7 +113,7 @@ func New() *HttpServer {
 		l.Fatal().Err(err).Msg("failed to get configuration of server")
 	}
 
-	return NewHttpServer(echo.New(), l, cfg, nil)
+	return NewHttpServer(echo.New(), l, cfg, authTool)
 }
 
 // StartServer is function that registers start of http server in lifecycle

--- a/server/http.go
+++ b/server/http.go
@@ -20,7 +20,7 @@ type HttpServer struct {
 	Echo     *echo.Echo
 	log      logger.Logger
 	config   *Config
-	authTool *middleware.AuthMiddleware
+	authTool middleware.AuthMiddleware
 }
 
 // Route is a http route.
@@ -47,12 +47,12 @@ func (h *HttpServer) AddRoute(route Route) {
 }
 
 // SetAuthMiddleware sets auth middleware to the router.
-func (h *HttpServer) SetAuthMiddleware(authTool *middleware.AuthMiddleware) {
+func (h *HttpServer) SetAuthMiddleware(authTool middleware.AuthMiddleware) {
 	h.authTool = authTool
 }
 
 // NewHttpServer returns new API instance.
-func NewHttpServer(e *echo.Echo, l logger.Logger, cfg *Config, authTool *middleware.AuthMiddleware) *HttpServer {
+func NewHttpServer(e *echo.Echo, l logger.Logger, cfg *Config, authTool middleware.AuthMiddleware) *HttpServer {
 	// sets CORS headers if Origin is present
 	e.Use(
 		echoMW.CORSWithConfig(echoMW.CORSConfig{

--- a/server/middleware/auth_auth0.go
+++ b/server/middleware/auth_auth0.go
@@ -11,8 +11,12 @@ import (
 	logger "github.com/webdevelop-pro/go-logger"
 )
 
+type AuthMiddleware interface {
+	Validate(next echo.HandlerFunc) echo.HandlerFunc
+}
+
 // AuthMiddleware is struct which store instance of auth middleware
-type AuthMiddleware struct {
+type authMiddleware struct {
 	validateURI string
 	log         logger.Logger
 }
@@ -23,15 +27,15 @@ type Config struct {
 }
 
 // NewAuthMW is a constructor of AuthMiddleware
-func NewAuth0MW(cfg *Config) *AuthMiddleware {
-	return &AuthMiddleware{
+func NewAuth0MW(cfg *Config) AuthMiddleware {
+	return &authMiddleware{
 		validateURI: cfg.AuthValidateURI,
 		log:         logger.NewComponentLogger("auth_tool", nil),
 	}
 }
 
 // NewAuthMiddleware returns a new instance of AuthMiddleware
-func NewAuthMiddleware() *AuthMiddleware {
+func NewAuthMiddleware() AuthMiddleware {
 	cfg := &Config{}
 	l := logger.NewComponentLogger("auth_tool", nil)
 
@@ -39,7 +43,7 @@ func NewAuthMiddleware() *AuthMiddleware {
 		l.Fatal().Err(err).Msg("failed to get configuration of db")
 	}
 
-	return &AuthMiddleware{
+	return &authMiddleware{
 		validateURI: cfg.AuthValidateURI,
 		log:         l,
 	}
@@ -48,7 +52,7 @@ func NewAuthMiddleware() *AuthMiddleware {
 // ToDo
 // Transfer headers ..
 // Validate is middleware that extracts data from Authorization header and validates it
-func (m *AuthMiddleware) Validate(next echo.HandlerFunc) echo.HandlerFunc {
+func (m *authMiddleware) Validate(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		var (
 			ctx = c.Request().Context()

--- a/server/middleware/auth_identity_id.go
+++ b/server/middleware/auth_identity_id.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog"
+	"github.com/webdevelop-pro/go-common/server/response"
+	logger "github.com/webdevelop-pro/go-logger"
+)
+
+type authIdentityHeaderMiddleware struct {
+	log logger.Logger
+}
+
+func NewAuthIdentityHeaderMW() AuthMiddleware {
+	l := logger.NewComponentLogger("auth_tool", nil)
+
+	return &authIdentityHeaderMiddleware{
+		log: l,
+	}
+}
+
+func (m *authIdentityHeaderMiddleware) Validate(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		identityID := c.Request().Header.Get("identity_id")
+
+		if identityID == "" {
+			return c.JSON(http.StatusUnauthorized, response.Error{
+				StatusCode: http.StatusUnauthorized,
+				Message: map[string][]string{
+					"errors": {"empty identity_id"},
+				},
+			})
+		}
+
+		ctx := c.Request().Context()
+		ctx = context.WithValue(ctx, "identity_id", identityID)
+		l := zerolog.Ctx(ctx).With().Str("user_id", identityID).Logger()
+		ctx = l.WithContext(ctx)
+		c.SetRequest(c.Request().WithContext(ctx))
+
+		return next(c)
+	}
+}

--- a/server/middleware/auth_identity_id.go
+++ b/server/middleware/auth_identity_id.go
@@ -24,7 +24,7 @@ func NewAuthIdentityHeaderMW() AuthMiddleware {
 
 func (m *authIdentityHeaderMiddleware) Validate(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		identityID := c.Request().Header.Get("identity_id")
+		identityID := c.Request().Header.Get("Authorization")
 
 		if identityID == "" {
 			return c.JSON(http.StatusUnauthorized, response.Error{

--- a/tests/actions.go
+++ b/tests/actions.go
@@ -39,6 +39,7 @@ type ExpectedResult map[string]interface{}
 type Request struct {
 	Scheme, Host, Method, Path string
 	Body                       []byte
+	Headers                    map[string]string
 }
 
 type ExpectedResponse struct {
@@ -48,7 +49,7 @@ type ExpectedResponse struct {
 
 func SendHttpRequst(req Request, checks ...ExpectedResponse) SomeAction {
 	return func(t TestContext) error {
-		result, code, err := SendTestRequest(CreateDefaultRequest(req.Scheme, req.Host, req.Method, req.Path, req.Body))
+		result, code, err := SendTestRequest(CreateDefaultRequest(req))
 
 		assert.Nil(t.T, err)
 

--- a/tests/examples/tests/example_test.go
+++ b/tests/examples/tests/example_test.go
@@ -39,6 +39,9 @@ func TestExample(t *testing.T) {
 					Request{
 						Scheme: "https",
 						Host:   "google.com",
+						Headers: map[string]string{
+							"identity_id": "test",
+						},
 						Method: "GET",
 						Path:   "/",
 					},

--- a/tests/general.go
+++ b/tests/general.go
@@ -68,8 +68,8 @@ func LoadEnv(envPath string) {
 	}
 }
 
-func CreateDefaultRequest(scheme, host, method, path string, body []byte) *http.Request {
-	if host == "" {
+func CreateDefaultRequest(req Request) *http.Request {
+	if req.Host == "" {
 		appHost := os.Getenv("HOST")
 		appPort := os.Getenv("PORT")
 
@@ -77,24 +77,29 @@ func CreateDefaultRequest(scheme, host, method, path string, body []byte) *http.
 			log.Fatalf("please set HOST and PORT vars")
 		}
 
-		host = appHost + ":" + appPort
+		req.Host = appHost + ":" + appPort
 	}
 
-	if scheme == "" {
-		scheme = "http"
+	if req.Scheme == "" {
+		req.Scheme = "http"
 	}
 
-	req, err := http.NewRequest(
-		method,
-		fmt.Sprintf("%s://%s%s", scheme, host, path),
-		bytes.NewBuffer((body)),
+	r, err := http.NewRequest(
+		req.Method,
+		fmt.Sprintf("%s://%s%s", req.Scheme, req.Host, req.Path),
+		bytes.NewBuffer((req.Body)),
 	)
 	if err != nil {
 		log.Fatalf("cannot create new request %s", err.Error())
 	}
 
-	req.Header.Add("content-type", "application/json")
-	return req
+	r.Header.Add("content-type", "application/json")
+
+	for key, value := range req.Headers {
+		r.Header.Add(key, value)
+	}
+
+	return r
 }
 
 func CreateRequestWithFiles(method, path string, body map[string]interface{}, files map[string]string) *http.Request {


### PR DESCRIPTION
@vladyslav2 я не нашел Middleware для авторизации через kratos, добавил сразу авторизацию через identity_id header. Его будет проставлять ory_oathkeeper, после проверки куков.

P.S. варианта как это писать сразу в body я не нашел, поэтому пускай наверное пока остаеться так, потом попробуем это в body писать