### PR TITLE
Fix: pubsub reconnect and some small fixes

### DIFF
--- a/db/pool.go
+++ b/db/pool.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/tracelog"
 	"github.com/webdevelop-pro/go-common/configurator"
@@ -12,8 +13,9 @@ import (
 )
 
 var (
-	pkgName = "db"
-	logger  = comLogger.NewComponentLogger(pkgName, nil)
+	pkgName    = "db"
+	logger     = comLogger.NewComponentLogger(pkgName, nil)
+	maxRetries = uint64(100)
 )
 
 func GetConfigPool(c *configurator.Configurator) *pgxpool.Config {
@@ -29,7 +31,6 @@ func GetConfigPool(c *configurator.Configurator) *pgxpool.Config {
 	}
 
 	pgxLogLevel, err := tracelog.LogLevelFromString(cfg.LogLevel)
-
 	if err != nil {
 		pgxLogLevel = tracelog.LogLevelNone
 	}
@@ -68,27 +69,21 @@ func NewPoolFromConfig(pgConfig *pgxpool.Config) *pgxpool.Pool {
 func newPool(pgConfig *pgxpool.Config) *pgxpool.Pool {
 	var pg *pgxpool.Pool
 	var err error
+	ctx := context.TODO()
 
-	// we need this to work correctly with GCP
-	i := 0
-	ticker := time.NewTicker(time.Second)
-
-	for ; ; <-ticker.C {
-		i++
-		// ToDo, show database type and host
-		// logger.Info().Msgf("Connecting to %s, attempt %d", cfg.Type, i)
-		logger.Info().Msgf("Connecting to db attempt %d", i)
-		pg, err = pgxpool.NewWithConfig(context.TODO(), pgConfig)
-		if err == nil || i > 60 {
-			break
-		}
-	}
-
+	pg, err = backoff.RetryWithData(
+		func() (*pgxpool.Pool, error) {
+			logger.Debug().Msgf("Connecting to db ")
+			return pgxpool.NewWithConfig(ctx, pgConfig)
+		},
+		backoff.WithContext(
+			backoff.WithMaxRetries(backoff.NewExponentialBackOff(), maxRetries),
+			ctx,
+		),
+	)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Unable to create connection pool")
 	}
-
-	ticker.Stop()
 
 	return pg
 }

--- a/db/readme.md
+++ b/db/readme.md
@@ -1,0 +1,3 @@
+## ToDo
+- [ ] Pass context for connection
+

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	cloud.google.com/go/compute v1.25.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.7 // indirect
+	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/queue/pclient/dto.go
+++ b/queue/pclient/dto.go
@@ -15,6 +15,7 @@ const (
 
 type Message struct {
 	Attributes map[string]string
+	Attempt    *int `json:"attempt"`
 	Data       []byte
 	ID         string `json:"message_id"`
 }
@@ -33,6 +34,7 @@ func NewMessage(data any, attributes map[string]string) (*Message, error) {
 
 type Event struct {
 	ID         string         `json:"id"`
+	Attempt    *int           `json:"attempt"`
 	Action     EventType      `json:"action" validate:"required"`
 	Sender     string         `json:"sender" validate:"required"`
 	ObjectID   int            `json:"object_id" validate:"required"`
@@ -44,6 +46,7 @@ type Event struct {
 
 type Webhook struct {
 	ID      string              `json:"id"`
+	Attempt *int                `json:"attempt"`
 	Action  string              `json:"action" validate:"required"`
 	Object  string              `json:"object" validate:"required"`
 	Service string              `json:"service" validate:"required"`

--- a/queue/pclient/listeners.go
+++ b/queue/pclient/listeners.go
@@ -6,8 +6,29 @@ import (
 	"fmt"
 
 	gpubsub "cloud.google.com/go/pubsub"
+	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/webdevelop-pro/go-common/context/keys"
 )
+
+const maxRetries = 100
+
+func (b *Client) getSubscriptionRetry(ctx context.Context, subscription, topic string) (*gpubsub.Subscription, error) {
+	sub, err := backoff.RetryWithData(
+		func() (*gpubsub.Subscription, error) {
+			b.log.Info().Msgf("Connecting to subscription %s/%s", topic, subscription)
+			return b.getSubscription(ctx, subscription, topic)
+		},
+		backoff.WithContext(
+			backoff.WithMaxRetries(backoff.NewExponentialBackOff(), maxRetries),
+			ctx,
+		),
+	)
+	if err != nil {
+		b.log.Error().Stack().Err(err).Msgf(ErrNotConnected.Error())
+		return nil, err
+	}
+	return sub, nil
+}
 
 func (b *Client) getSubscription(ctx context.Context, subscription, topic string) (*gpubsub.Subscription, error) {
 	var err error
@@ -23,45 +44,46 @@ func (b *Client) getSubscription(ctx context.Context, subscription, topic string
 
 	ok, err := bTopic.Exists(ctx)
 	if !ok {
-		b.log.Fatal().Stack().Err(err).Str("topic", topic).Msgf(ErrTopicNotExists.Error())
+		b.log.Error().Err(err).Str("topic", topic).Msgf(ErrTopicNotExists.Error())
 		return nil, fmt.Errorf("%w: %s", ErrTopicNotExists, bTopic.ID())
 	}
 
 	if err != nil {
-		b.log.Fatal().Stack().Err(err).Str("topic", topic).Msgf(ErrTopicConnect.Error())
+		b.log.Error().Err(err).Str("topic", topic).Msgf(ErrTopicConnect.Error())
 		return nil, fmt.Errorf("%w: %w", ErrTopicConnect, err)
 	}
 
 	sub := b.client.Subscription(subscription)
 	ok, err = sub.Exists(ctx)
 	if err != nil {
-		b.log.Fatal().Stack().Err(err).Interface("name", subscription).Msgf(ErrConnectSubscription.Error())
+		b.log.Error().Err(err).Str("subscription", subscription).Msgf(ErrConnectSubscription.Error())
 		return nil, fmt.Errorf("%w: %w", ErrConnectSubscription, err)
 	}
 	if !ok {
-		b.log.Fatal().Stack().Err(err).Interface("name", subscription).Msgf(ErrSubscriptionNotExist.Error())
+		b.log.Error().Err(err).Str("subscription", subscription).Msgf(ErrSubscriptionNotExist.Error())
 		return nil, fmt.Errorf("%w: %w", ErrSubscriptionNotExist, err)
 	}
 	return sub, nil
 }
 
 func (b *Client) ListenRawMsgs(ctx context.Context, subscription, topic string, callback func(ctx context.Context, msg Message) error) error {
-	sub, err := b.getSubscription(ctx, subscription, topic)
+	sub, err := b.getSubscriptionRetry(ctx, subscription, topic)
 	if err != nil {
 		return err
 	}
-	go b.listenRawGoroutine(ctx, callback, sub)
-	return nil
+	return b.listenRawGoroutine(ctx, callback, sub)
 }
 
 func (b *Client) listenRawGoroutine(ctx context.Context, callback func(ctx context.Context, msg Message) error, sub *gpubsub.Subscription) error {
 	// Start consuming messages from the subscription
+	b.log.Trace().Msgf("connected to subscription %s listen messages", sub.ID())
 	err := sub.Receive(ctx, func(ctx context.Context, msg *gpubsub.Message) {
 		// Unmarshal the message data into a struct
 		m := Message{}
 		m.Data = msg.Data
 		m.Attributes = msg.Attributes
 		m.ID = msg.ID
+		m.Attempt = msg.DeliveryAttempt
 
 		ctx = keys.SetCtxValue(ctx, keys.MSGID, msg.ID)
 		b.log.Trace().Str("msg", string(m.Data)).Msgf("received message")
@@ -74,25 +96,23 @@ func (b *Client) listenRawGoroutine(ctx context.Context, callback func(ctx conte
 		msg.Ack()
 	})
 	if err != nil {
-		b.log.Fatal().Stack().Err(err).Msgf(ErrReceiveSubscription.Error())
+		b.log.Error().Stack().Err(err).Msgf(ErrReceiveSubscription.Error())
 	}
-	b.log.Trace().Msgf("connected to subscription %s listen messages", sub.ID())
-	<-ctx.Done()
-	b.log.Trace().Msgf("stop listen messages for %s", sub.ID())
-	return nil
+	return err
 }
 
 func (b *Client) ListenWebhooks(ctx context.Context, subscription, topic string, callback func(ctx context.Context, msg Webhook) error) error {
-	sub, err := b.getSubscription(ctx, subscription, topic)
+	sub, err := b.getSubscriptionRetry(ctx, subscription, topic)
 	if err != nil {
 		return err
 	}
-	go b.listenWebhookGoroutine(ctx, callback, sub)
-	return nil
+
+	return b.listenWebhookGoroutine(ctx, callback, sub)
 }
 
 func (b *Client) listenWebhookGoroutine(ctx context.Context, callback func(ctx context.Context, msg Webhook) error, sub *gpubsub.Subscription) error {
 	// Start consuming messages from the subscription
+	b.log.Trace().Msgf("connected to subscription %s listen for webhooks", sub.ID())
 	err := sub.Receive(ctx, func(ctx context.Context, msg *gpubsub.Message) {
 		webhook := Webhook{}
 		if err := json.Unmarshal(msg.Data, &webhook); err != nil {
@@ -101,6 +121,7 @@ func (b *Client) listenWebhookGoroutine(ctx context.Context, callback func(ctx c
 			return
 		}
 		webhook.ID = msg.ID
+		webhook.Attempt = msg.DeliveryAttempt
 
 		ctx = SetDefaultWebhookCtx(ctx, webhook)
 		b.log.Trace().Interface("msg", webhook).Msgf("received webhook")
@@ -113,25 +134,22 @@ func (b *Client) listenWebhookGoroutine(ctx context.Context, callback func(ctx c
 		msg.Ack()
 	})
 	if err != nil {
-		b.log.Fatal().Stack().Err(err).Msgf(ErrReceiveSubscription.Error())
+		b.log.Error().Stack().Err(err).Msgf(ErrReceiveSubscription.Error())
 	}
-	b.log.Trace().Msgf("connected to subscription %s listen for webhooks", sub.ID())
-	<-ctx.Done()
-	b.log.Trace().Msgf("stop listen for webhooks for %s", sub.ID())
-	return nil
+	return err
 }
 
 func (b *Client) ListenEvents(ctx context.Context, subscription, topic string, callback func(ctx context.Context, msg Event) error) error {
-	sub, err := b.getSubscription(ctx, subscription, topic)
+	sub, err := b.getSubscriptionRetry(ctx, subscription, topic)
 	if err != nil {
 		return err
 	}
-	go b.listenEventGoroutine(ctx, callback, sub)
-	return nil
+	return b.listenEventGoroutine(ctx, callback, sub)
 }
 
 func (b *Client) listenEventGoroutine(ctx context.Context, callback func(ctx context.Context, msg Event) error, sub *gpubsub.Subscription) error {
 	// Start consuming messages from the subscription
+	b.log.Trace().Msgf("connected to subscription %s listen for events", sub.ID())
 	err := sub.Receive(ctx, func(ctx context.Context, msg *gpubsub.Message) {
 		event := Event{}
 		if err := json.Unmarshal(msg.Data, &event); err != nil {
@@ -140,6 +158,7 @@ func (b *Client) listenEventGoroutine(ctx context.Context, callback func(ctx con
 			return
 		}
 		event.ID = msg.ID
+		event.Attempt = msg.DeliveryAttempt
 
 		ctx = SetDefaultEventCtx(ctx, event)
 
@@ -153,10 +172,7 @@ func (b *Client) listenEventGoroutine(ctx context.Context, callback func(ctx con
 		msg.Ack()
 	})
 	if err != nil {
-		b.log.Fatal().Stack().Err(err).Msgf(ErrReceiveSubscription.Error())
+		b.log.Error().Stack().Err(err).Msgf(ErrReceiveSubscription.Error())
 	}
-	b.log.Trace().Msgf("connected to subscription %s listen for events", sub.ID())
-	<-ctx.Done()
-	b.log.Trace().Msgf("stop listen for events for %s", sub.ID())
-	return nil
+	return err
 }

--- a/queue/pclient/readme.md
+++ b/queue/pclient/readme.md
@@ -8,5 +8,4 @@
 - dont forget to create topic using by using [CreateTopic](./client.go) client method
 
 ## ToDo
-- [ ] Check if topic is still valid and exist (in case if someone delete it)
-- [ ] Check if subscription is still valid and exist (in case if someone delete it)
+- [ ] Do not parse config file all the time use configurator

--- a/queue/pubsub.go
+++ b/queue/pubsub.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"time"
 
 	"github.com/webdevelop-pro/go-common/configurator"
 	"github.com/webdevelop-pro/go-common/queue/pclient"
@@ -50,15 +51,36 @@ func (p PubSubListener) Start() {
 		br := b
 
 		if br.Name == "webhooks" {
-			go p.client.ListenWebhooks(ctx, br.Subscription, br.Topic, br.WebhooksListener)
+			go func() {
+			CONNECT_WEBHOOKS:
+				err := p.client.ListenWebhooks(ctx, br.Subscription, br.Topic, br.WebhooksListener)
+				if err != nil {
+					time.Sleep(2 * time.Second)
+					goto CONNECT_WEBHOOKS
+				}
+			}()
 			continue
 		}
 		if br.Name == "events" {
-			go p.client.ListenEvents(ctx, br.Subscription, br.Topic, br.EventsListener)
+			go func() {
+			CONNECT_EVENTS:
+				err := p.client.ListenEvents(ctx, br.Subscription, br.Topic, br.EventsListener)
+				if err != nil {
+					time.Sleep(2 * time.Second)
+					goto CONNECT_EVENTS
+				}
+			}()
 			continue
 		}
 		if br.Name == "messages" {
-			go p.client.ListenRawMsgs(ctx, br.Subscription, br.Topic, br.MsgsListener)
+			go func() {
+			CONNECT_RAW:
+				err := p.client.ListenRawMsgs(ctx, br.Subscription, br.Topic, br.MsgsListener)
+				if err != nil {
+					time.Sleep(2 * time.Second)
+					goto CONNECT_RAW
+				}
+			}()
 			continue
 		}
 		log := logger.NewComponentLogger("pubsub", nil)

--- a/server/middleware/fake_identity_id_check.go
+++ b/server/middleware/fake_identity_id_check.go
@@ -1,0 +1,24 @@
+package middleware
+
+import (
+	"github.com/labstack/echo/v4"
+	logger "github.com/webdevelop-pro/go-logger"
+)
+
+type fakeIdentityHeaderMiddleware struct {
+	log logger.Logger
+}
+
+func NewFakeIdentityHeaderMW() AuthMiddleware {
+	l := logger.NewComponentLogger("auth_tool", nil)
+
+	return &fakeIdentityHeaderMiddleware{
+		log: l,
+	}
+}
+
+func (m *fakeIdentityHeaderMiddleware) Validate(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		return next(c)
+	}
+}

--- a/tests/general.go
+++ b/tests/general.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -266,20 +267,33 @@ func RunApiTestV2(t *testing.T, Description string, scenario ApiTestCaseV2) {
 	})
 }
 
-func allowAny(src, dst map[string]interface{}) {
+func allowDictAny(src, dst map[string]interface{}) {
 	for k, v := range dst {
 		switch val := v.(type) {
 		case string:
 			if val == "%any%" {
 				dst[k] = src[k]
 			}
-			/*
-				case int:
-					if val == math.MinInt {
-						dst[k] = src[k]
-					}
-			*/
+		case int:
+			if val == math.MinInt {
+				dst[k] = src[k]
+			}
 		}
+	}
+}
+
+func allowAny(src, dst interface{}) {
+	switch val := dst.(type) {
+	case string:
+		if val == "%any%" {
+			dst = src
+		}
+	case int:
+		if val == math.MinInt {
+			dst = src
+		}
+	default:
+		fmt.Println("not implemented ")
 	}
 }
 
@@ -311,6 +325,6 @@ func CompareJsonBody(t *testing.T, actual, expected []byte) {
 		return
 	}
 
-	allowAny(actualBody, expectedBody)
+	allowDictAny(actualBody, expectedBody)
 	assert.EqualValuesf(t, expectedBody, actualBody, "responses not equal")
 }

--- a/tests/sql.go
+++ b/tests/sql.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,7 +20,11 @@ func AssertSQL(t *testing.T, fManager FixturesManager, testCase SQLTestCase) {
 
 	actualResult, err := fManager.SelectQuery(testCase.ExpectedSelectQuery)
 	if err != nil {
-		assert.FailNow(t, err.Error()+fmt.Sprintf(" failed sql: %s", testCase.ExpectedSelectQuery))
+		query := strings.Replace(testCase.ExpectedSelectQuery, "\t", " ", -1)
+		query = strings.Replace(query, "\n", " ", -1)
+		query = strings.Replace(query, "  ", " ", -1)
+		query = strings.Replace(query, "  ", " ", -1)
+		assert.FailNow(t, err.Error()+fmt.Sprintf(" failed sql: %s", query))
 	}
 
 	CompareJsonBody(t, []byte(actualResult), []byte(testCase.ExpectedResult))


### PR DESCRIPTION
webdevelop-pro/invest.webdevelop.pro#574

PubSub:
- PubSub does not call Fatal() anymore
- PubSub will try to reconnect using exponential back off if topic/subscription been deleted
- PubSub will try to reconnect if listen function fail
- PubSub Message have Attempt counter

Small fixes:
- PG will use exponential back off to connect to db
- fakeIdentityHeaderMiddleware which not required to have Authentication Header
- Validation return errros in lowercase without .
- tests: show sql during sql error
- tests: try to execute sql for 15 times with 0.5 seconds delay