### PR TITLE
Feat: create route as standalone entity, refactor http

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,4 +4,5 @@
 - [ ] eliminate go-echo-swagger, upload swagger files to docs.<domain>.com/service. Go-echo-swagger adds a lot of dependencies and slows down every request
 - [ ] [server/middleware/ip_address.go#L18](use echo.RealIP()) instead of our custom code
 - [ ] Set up proper middleware to get user ip address correctly, https://echo.labstack.com/docs/ip-address
+- [ ] create an ability to install each folder individually, similary to [pgtype](https://github.com/jackc/pgx/tree/master/pgtype). Cause right now if you need only `configurator` you will also install a lot of dependencies
 

--- a/server/route/readme.md
+++ b/server/route/readme.md
@@ -1,0 +1,34 @@
+# http routing
+
+Define routing handler and create `GetRoutes` function which should return `route.Route`
+
+```golang
+type Handler struct {
+	app service.App
+}
+
+func NewHandler() *Handler {
+	h := Handler{}
+	return &h
+}
+
+func (hg Handler) GetRoutes() []route.Route {
+	tokenValidatorMiddleware := middleware.KeyAuth(func(key string, c echo.Context) (bool, error) {
+		return key == "valid-key", nil
+	})
+
+	return []route.Route{
+		{
+			Method: http.MethodHead,
+			Path:   "/api/v1.0/healthcheck",
+			Handle: hg.healthCheck,
+		},
+		{
+			Method:      http.MethodPost,
+			Path:        "/v1.0/user",
+			Handle:      hg.createUser,
+			Middlewares: []echo.MiddlewareFunc{tokenValidatorMiddleware},
+		},
+  }
+}
+```

--- a/server/route/route.go
+++ b/server/route/route.go
@@ -1,0 +1,36 @@
+package route
+
+import (
+	"github.com/labstack/echo/v4"
+	"go.uber.org/fx"
+)
+
+// Route is a http route.
+type Route struct {
+	Method      string
+	Path        string
+	Handle      echo.HandlerFunc
+	Middlewares []echo.MiddlewareFunc
+}
+
+type Configurator interface {
+	GetRoutes() []Route
+}
+
+type ConfiguratorOut struct {
+	fx.Out
+
+	RG Configurator `group:"route_configurator"`
+}
+
+type ConfiguratorIn struct {
+	// fx.In
+
+	Configurators []Configurator `group:"route_configurator"`
+}
+
+func NewConfigurator(rg Configurator) ConfiguratorOut {
+	return ConfiguratorOut{
+		RG: rg,
+	}
+}

--- a/server/route/route_test.go
+++ b/server/route/route_test.go
@@ -1,0 +1,13 @@
+package route
+
+import (
+	"testing"
+
+	"github.com/go-playground/assert/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoute(t *testing.T) {
+	// route := Route{}
+	assert.Fail("add tests for the route")
+}


### PR DESCRIPTION
webdevelop-pro/invest.webdevelop.pro#0000

  - Created route package to clean up http.go

BREAKING CHANGE:
  - removed auth tool from the HTTPServer by default
  - application no more need to do InitRoutes
  - instead call server.InitAllRoutes in fx.Invoke